### PR TITLE
Open a file in text mode before writing tsv lines

### DIFF
--- a/google_drive_download.py
+++ b/google_drive_download.py
@@ -126,7 +126,7 @@ def download_all_files(iris_folder_id, dest_dir, drive_service):
 
     temp_name = None
     try:
-        with tempfile.NamedTemporaryFile(delete=False) as temp_handle:
+        with tempfile.NamedTemporaryFile(mode='wt', delete=False) as temp_handle:
             temp_name = temp_handle.name
 
             write_file_tsv(all_files, TOP_DIR_NAME, temp_handle)


### PR DESCRIPTION
This avoids an error like:
`TypeError: a bytes-like object is required, not 'str'`

In response to: https://github.com/Xinglab/IRIS/issues/8